### PR TITLE
Upload local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The supplied `docs/upload-local-file.sh` provides an example of how to upload a 
 * download the example ocr image `wget http://bit.ly/ocrimage`
 * example: `docs/upload-local-file.sh http://10.0.2.15:$HTTP_PORT/ocr-file-upload ocrimage` 
 
+
 # Community
 
 * Follow [@OpenOCR](https://twitter.com/openocr) on Twitter

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ The REST API also supports:
 See the [REST API docs](http://docs.openocr.apiary.io/) and the [Go REST client](http://github.com/tleyden/open-ocr-client) for details.
 
 
+# Uploading local files using curl
+
+The supplied `docs/upload-local-file.sh` provides an example of how to upload a local file using curl with `multipart/related` encoding of the json and image data:
+* usage: `docs/upload-local-file.sh <urlendpoint> <file> [mimetype]`
+* download the example ocr image `wget http://bit.ly/ocrimage`
+* example: `docs/upload-local-file.sh http://10.0.2.15:$HTTP_PORT/ocr-file-upload ocrimage` 
+
 # Community
 
 * Follow [@OpenOCR](https://twitter.com/openocr) on Twitter

--- a/docs/upload-local-file.sh
+++ b/docs/upload-local-file.sh
@@ -22,7 +22,7 @@ MIME_TYPE=${3:-"image/png"}
 ( echo "--$BOUNDARY
 Content-Type: application/json; charset=UTF-8
 
-{ \"engine\": \"tesseract\", \"preprocessors\":[\"stroke-width-transform\"] }
+{ \"engine\": \"tesseract\" }
 
 --$BOUNDARY
 Content-Type: $MIME_TYPE

--- a/docs/upload-local-file.sh
+++ b/docs/upload-local-file.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Upload a file to open-ocr
+#
+# Usage: upload.sh <url> <file> [mime]
+#    eg: upload.sh http://10.0.0.1:8080/ocr-file-upload ocrimage image/png
+#
+# (with addition of CRLF around the json....) thanks to https://github.com/soulseekah/bash-utils/blob/master/google-drive-upload/upload.sh
+
+set -e
+
+URL=${1:-http://10.0.0.1:8080/ocr-file-upload}
+FILE=${2}
+if [ ! -f "${FILE}" ]; then
+	echo "ERROR: cannot find file: '${FILE}'"
+	exit 42
+fi
+
+BOUNDARY=`cat /dev/urandom | head -c 16 | xxd -ps`
+MIME_TYPE=${3:-"image/png"}
+
+( echo "--$BOUNDARY
+Content-Type: application/json; charset=UTF-8
+
+{ \"engine\": \"tesseract\", \"preprocessors\":[\"stroke-width-transform\"] }
+
+--$BOUNDARY
+Content-Type: $MIME_TYPE
+Content-Disposition: attachment; filename=\"attachment.txt\".
+" \
+&& cat $FILE && echo "
+--$BOUNDARY--" ) \
+	| curl -v -X POST "$URL" \
+	--header "Content-Type: multipart/related; boundary=\"$BOUNDARY\"" \
+	--data-binary "@-"
+

--- a/docs/upload-local-file.sh
+++ b/docs/upload-local-file.sh
@@ -34,3 +34,11 @@ Content-Disposition: attachment; filename=\"attachment.txt\".
 	--header "Content-Type: multipart/related; boundary=\"$BOUNDARY\"" \
 	--data-binary "@-"
 
+# if you want to use the stroke-width-transform preprocessor then swap the line:
+# 
+# { \"engine\": \"tesseract\" }
+#
+# With:
+#
+# { \"engine\": \"tesseract\", \"preprocessors\":[\"stroke-width-transform\"] }
+#


### PR DESCRIPTION
1. Added script `docs/upload-local-file.sh` to facilitate uploading a local file to the endpoint `/ocr-file-upload` using just CURL and bash.

2. Added mention at the end of the README.md as the first thing I wanted to do was push _my files_ into OpenOCR!
