### PR TITLE
Make DNS entries into lists

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 # Start messaging broker
 rabbitmq:
   image: tutum/rabbitmq
-  dns: 8.8.8.8
+  dns: ["8.8.8.8"]
   environment:
     - "RABBITMQ_PASS=Phaish9ohbaidei6oole"
 
@@ -10,7 +10,7 @@ strokewidthtransform:
   image: tleyden5iwx/open-ocr-preprocessor
   volumes: 
     - ./scripts/:/opt/open-ocr/
-  dns: 8.8.8.8
+  dns: ["8.8.8.8"]
   links:
     - rabbitmq
   command: "/opt/open-ocr/open-ocr-preprocessor -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/ -preprocessor stroke-width-transform"
@@ -20,7 +20,7 @@ openocrworker:
   image: tleyden5iwx/open-ocr
   volumes: 
     - ./scripts/:/opt/open-ocr/
-  dns: 8.8.8.8
+  dns: ["8.8.8.8"]
   links:
     - rabbitmq
   command: "/opt/open-ocr/open-ocr-worker -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/"
@@ -28,7 +28,7 @@ openocrworker:
 # Start http server
 openocr:
   image: tleyden5iwx/open-ocr
-  dns: 8.8.8.8
+  dns: ["8.8.8.8"]
   volumes: 
     - ./scripts/:/opt/open-ocr/
   links:


### PR DESCRIPTION
@tleyden This pull request fixes an issue I ran into while testing out `open-ocr` on OS. Here's my environment:
```
$ docker -v
Docker version 1.9.1, build a34a1d5
$ docker-machine -version
docker-machine version 0.5.1 (HEAD)
$ docker-compose -v
docker-compose version 1.5.2, build unknown
```

On HEAD, I get the following error:
```
~/opensource/open-ocr/docker-compose $ docker-compose up -d
Recreating dockercompose_rabbitmq_1
ERROR: json: cannot unmarshal string into Go value of type []string
```

The fix is as suggested in https://github.com/docker/compose/issues/2515#issuecomment-163214982.
 After updating the DNS entries in `docker-compose.yml` to be lists, I get the following output, and the service seems to work:
```
~/opensource/open-ocr/docker-compose $ docker-compose up -d
Starting 9f539a3813_dockercompose_rabbitmq_1
Starting dockercompose_openocr_1
Starting dockercompose_strokewidthtransform_1
Starting dockercompose_openocrworker_1
```

Thanks for putting all your work into `open-ocr`! Other than this minor issue with the docker setup, it seems to work perfectly for my use case!