### PR TITLE
remove absolute path because binaries already in a PATH

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@ strokewidthtransform:
   dns: ["8.8.8.8"]
   links:
     - rabbitmq
-  command: "/opt/open-ocr/open-ocr-preprocessor -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/ -preprocessor stroke-width-transform"
+  command: open-ocr-preprocessor -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/ -preprocessor stroke-width-transform
 
 # Start OCR worker
 openocrworker:
@@ -23,7 +23,7 @@ openocrworker:
   dns: ["8.8.8.8"]
   links:
     - rabbitmq
-  command: "/opt/open-ocr/open-ocr-worker -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/"
+  command: open-ocr-worker -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/
 
 # Start http server
 openocr:
@@ -35,4 +35,4 @@ openocr:
     - rabbitmq
   ports:
     - "9292:9292"
-  command: "/opt/open-ocr/open-ocr-httpd -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/ -http_port 9292"
+  command: open-ocr-httpd -amqp_uri amqp://admin:Phaish9ohbaidei6oole@rabbitmq/ -http_port 9292


### PR DESCRIPTION
It solves issue #64 and actually we don't need absolute path here because binaries already in a /usr/bin which is part of **PATH**