### PR TITLE
Convert pdf preprocessor

### DIFF
--- a/cli-preprocessor/main.go
+++ b/cli-preprocessor/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/couchbaselabs/logg"
-	ocrworker "github.com/tleyden/open-ocr"
+	"github.com/xf0e/open-ocr"
 )
 
 // This assumes that there is a rabbit mq running

--- a/cli-preprocessor/main.go
+++ b/cli-preprocessor/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/couchbaselabs/logg"
-	"github.com/xf0e/open-ocr"
+	ocrworker "github.com/tleyden/open-ocr"
 )
 
 // This assumes that there is a rabbit mq running

--- a/convert-pdf.go
+++ b/convert-pdf.go
@@ -1,0 +1,78 @@
+package ocrworker
+
+/*	Use this module if you want to call tesseract over
+	pdfsandwich with an image as input file.
+	Useful with big documents.
+
+	Use cases:
+	engine: tesseract with file_type: pdf and preprocessor: convert-pdf
+	engine: sandwich  with file_type: [tif, png, jpg] and preprocessor: convert-pdf
+*/
+
+import (
+	"fmt"
+	"github.com/couchbaselabs/logg"
+	"io/ioutil"
+	"os/exec"
+)
+
+type ConvertPdf struct {
+}
+
+func (c ConvertPdf) preprocess(ocrRequest *OcrRequest) error {
+
+	tmpFileNameInput, err := createTempFileName()
+	tmpFileNameInput = fmt.Sprintf("%s.pdf", tmpFileNameInput)
+	if err != nil {
+		return err
+	}
+	//defer os.Remove(tmpFileNameInput)
+
+	tmpFileNameOutput, err := createTempFileName()
+	tmpFileNameOutput = fmt.Sprintf("%s.tif", tmpFileNameOutput)
+	if err != nil {
+		return err
+	}
+	//defer os.Remove(tmpFileNameOutput)
+
+	err = saveBytesToFileName(ocrRequest.ImgBytes, tmpFileNameInput)
+	if err != nil {
+		return err
+	}
+
+	logg.LogTo(
+		"PREPROCESSOR_WORKER",
+		"Convert PDF %s -> %s",
+		tmpFileNameInput,
+		tmpFileNameOutput,
+	)
+	/*
+	   gs -dQUIET -o Antrag.tif -sDEVICE=tiffg4 Antrag.pdf
+	*/
+	var gsArgs []string
+	gsArgs = append(gsArgs,
+		"-dQUIET",
+		"-dNOPAUSE",
+		"-dBATCH",
+		"-sOutputFile="+tmpFileNameOutput,
+		"-sDEVICE=tiffg4",
+		tmpFileNameInput,
+	)
+	logg.LogTo("PREPROCESSOR_WORKER", "output: %s", gsArgs)
+
+	out, err := exec.Command("gs", gsArgs...).CombinedOutput()
+	if err != nil {
+		logg.LogFatal("Error running command: %s. out: %s", err, out)
+	}
+	logg.LogTo("PREPROCESSOR_WORKER", "output: %v", string(out))
+
+	// read bytes from output file
+	resultBytes, err := ioutil.ReadFile(tmpFileNameOutput)
+
+	if err != nil {
+		return err
+	}
+	ocrRequest.ImgBytes = resultBytes
+
+	return nil
+}

--- a/convert-pdf.go
+++ b/convert-pdf.go
@@ -47,9 +47,7 @@ func (c ConvertPdf) preprocess(ocrRequest *OcrRequest) error {
 		tmpFileNameInput,
 		tmpFileNameOutput,
 	)
-	/*
-	   gs -dQUIET -o Antrag.tif -sDEVICE=tiffg4 Antrag.pdf
-	*/
+
 	var gsArgs []string
 	gsArgs = append(gsArgs,
 		"-dQUIET",

--- a/convert-pdf.go
+++ b/convert-pdf.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/couchbaselabs/logg"
 	"io/ioutil"
+	"os"
 	"os/exec"
 )
 
@@ -26,14 +27,14 @@ func (c ConvertPdf) preprocess(ocrRequest *OcrRequest) error {
 	if err != nil {
 		return err
 	}
-	//defer os.Remove(tmpFileNameInput)
+	defer os.Remove(tmpFileNameInput)
 
 	tmpFileNameOutput, err := createTempFileName()
 	tmpFileNameOutput = fmt.Sprintf("%s.tif", tmpFileNameOutput)
 	if err != nil {
 		return err
 	}
-	//defer os.Remove(tmpFileNameOutput)
+	defer os.Remove(tmpFileNameOutput)
 
 	err = saveBytesToFileName(ocrRequest.ImgBytes, tmpFileNameInput)
 	if err != nil {

--- a/preprocessor.go
+++ b/preprocessor.go
@@ -1,7 +1,8 @@
 package ocrworker
 
-const PREPROCESSOR_IDENTITY = "identity"
-const PREPROCESSOR_STROKE_WIDTH_TRANSFORM = "stroke-width-transform"
+const PreprocessorIdentity = "identity"
+const PreprocessorStrokeWidthTransform = "stroke-width-transform"
+const PreprocessorConvertPdf = "convert-pdf"
 
 type Preprocessor interface {
 	preprocess(ocrRequest *OcrRequest) error

--- a/stroke_width_transform.go
+++ b/stroke_width_transform.go
@@ -74,7 +74,7 @@ func (s StrokeWidthTransformer) extractDarkOnLightParam(ocrRequest OcrRequest) s
 	val := "1"
 
 	preprocessorArgs := ocrRequest.PreprocessorArgs
-	swtArgs := preprocessorArgs[PREPROCESSOR_STROKE_WIDTH_TRANSFORM]
+	swtArgs := preprocessorArgs[PreprocessorStrokeWidthTransform]
 	if swtArgs != nil {
 		swtArg, ok := swtArgs.(string)
 		if ok && (swtArg == "0" || swtArg == "1") {


### PR DESCRIPTION
The tesseract engine now can be confronted with pdf files. This is achieved by a new **ConvertPdf** preprocessor. 

**Usage:**
- The preprocessor binary should be started with **-preprocessor convert-pdf"
and afterwards it can be tested with:
 -    curl -X POST -H "Content-Type: application/json" -d '{"img_url":"http://localhost:8000/test.pdf","engine":"tesseract", "preprocessors":["convert-pdf"]}' http://localhost:8080/ocr

Internal we are calling **gs** to create a multi page TIFF from our input. The ImageMagick won't work for this purpose because it creates a single paged image files which tesseract can't handle.
e.g.
> Tesseract Open Source OCR Engine v4.0.0 with Leptonica
> Page 1
> Image too large: (2480, 77176)
> Error during processing.

Regards!